### PR TITLE
레이아웃 리팩터링 및 NotFound 페이지 추가

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-import { ToastContainer } from "react-toastify";
+import ToastProvider from "@/components/ToastProvider";
 // import { ClerkProvider } from "@clerk/nextjs";
 
 const geistSans = Geist({
@@ -37,7 +37,7 @@ export default function RootLayout({
           {children}
           <Footer />
         </div>
-        <ToastContainer position="bottom-right" />
+        <ToastProvider />
       </body>
     </html>
     // </ClerkProvider>

--- a/apps/client/src/app/not-found.tsx
+++ b/apps/client/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+      <h2 className="text-4xl font-bold">404</h2>
+      <p className="text-gray-600">페이지를 찾을 수 없습니다.</p>
+      <Link href="/" className="text-blue-600 hover:text-blue-800 underline">
+        홈으로 돌아가기
+      </Link>
+    </div>
+  );
+}

--- a/apps/client/src/app/products/[id]/page.tsx
+++ b/apps/client/src/app/products/[id]/page.tsx
@@ -1,14 +1,15 @@
 import ProductInteraction from "@/components/ProductInteraction";
 import { ProductType } from "@repo/types";
 import Image from "next/image";
-import { getMockProductById } from "@/lib/mock-data";
+import { notFound } from "next/navigation";
+import { getMockProductById, mockProducts } from "@/lib/mock-data";
 
 const fetchProduct = async (id: string): Promise<ProductType> => {
   // Use mock data instead of fetch
   const product = getMockProductById(id);
   
   if (!product) {
-    throw new Error(`Product with id ${id} not found`);
+    notFound();
   }
   
   return product;
@@ -19,6 +20,12 @@ const fetchProduct = async (id: string): Promise<ProductType> => {
   // const data: ProductType = await res.json();
   // return data;
 };
+
+export async function generateStaticParams() {
+  return mockProducts.map((product) => ({
+    id: product.id,
+  }));
+}
 
 export const generateMetadata = async ({
   params,

--- a/apps/client/src/components/ToastProvider.tsx
+++ b/apps/client/src/components/ToastProvider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+export default function ToastProvider() {
+  return <ToastContainer position="bottom-right" />;
+}
+


### PR DESCRIPTION
- layout.tsx에서 ToastContainer를 커스텀 ToastProvider로 교체
- 404 처리를 위한 새로운 NotFound 컴포넌트 추가
- 상품 페이지에서 누락된 상품에 대해 notFound() 사용 및 정적 파라미터 생성 로직 추가