### PR TITLE
feature(web): 회원가입 API 연결 및 SignUpForm 리팩토링

### DIFF
--- a/apps/client/src/@components/signup/address/AddressModal.tsx
+++ b/apps/client/src/@components/signup/address/AddressModal.tsx
@@ -24,7 +24,7 @@ const AddressModal = ({
       <DialogContent
         showCloseButton={false}
         onOpenAutoFocus={(e) => e.preventDefault()}
-        className="w-[calc(100vw-1rem)] sm:w-[calc(100vw-2rem)] max-w-2xl max-h-[95vh] sm:max-h-[90vh] p-0 rounded-2xl border-0 shadow-2xl bg-background flex flex-col"
+        className="w-[calc(100vw-1rem)]  max-w-2xl max-h-[95vh] sm:max-h-[90vh] p-0 rounded-2xl border-0 shadow-2xl bg-background flex flex-col"
       >
         {/* Header with Close Button */}
         <div className="relative flex items-center justify-end px-4 sm:px-6 pt-4 sm:pt-6 pb-3 flex-shrink-0">

--- a/apps/client/src/@layout/signup/hooks/useSignUpForm.ts
+++ b/apps/client/src/@layout/signup/hooks/useSignUpForm.ts
@@ -1,0 +1,131 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useRegister } from "@/@service/auth/mutations";
+import { signUpSchema, SignUpFormInputs, FieldState } from "../schema";
+import { RegisterRequest } from "@/@service/auth/types";
+
+export const useSignUpForm = () => {
+  const router = useRouter();
+  const registerMutation = useRegister();
+
+  const form = useForm<SignUpFormInputs>({
+    resolver: zodResolver(signUpSchema),
+    mode: "onChange",
+    defaultValues: {
+      daumPostAddress: "",
+      extraAddress: "",
+    },
+  });
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isValid },
+  } = form;
+
+  // 폼 필드 값들을 watch로 실시간 추적
+  const fullName = watch("fullName");
+  const email = watch("email");
+  const password = watch("password");
+  const phone = watch("phone");
+  const daumPostAddress = watch("daumPostAddress");
+  const extraAddress = watch("extraAddress");
+
+  /**
+   * 필드 상태를 계산하는 헬퍼 함수
+   * - initial: 값이 없을 때
+   * - error: 에러가 있을 때
+   * - success: 값이 있고 에러가 없을 때
+   */
+  const getFieldState = (
+    fieldName: keyof SignUpFormInputs,
+    value: string | undefined
+  ): FieldState => {
+    if (!value) return "initial";
+    if (errors[fieldName]) return "error";
+    return "success";
+  };
+
+  // 각 필드의 상태를 계산
+  const fieldStates = {
+    fullName: getFieldState("fullName", fullName),
+    email: getFieldState("email", email),
+    password: getFieldState("password", password),
+    phone: getFieldState("phone", phone),
+    daumPostAddress: getFieldState("daumPostAddress", daumPostAddress),
+    extraAddress: getFieldState("extraAddress", extraAddress),
+  };
+
+  // 폼 유효성 검사 (모든 필수 필드가 채워져 있고 유효한지 확인)
+  const isFormValid = isValid && !!fullName && !!email && !!password && !!phone;
+
+  /**
+   * 폼 제출 핸들러
+   * - API 요청 형식에 맞게 데이터 변환
+   * - 회원가입 API 호출
+   * - 성공 시 로그인 페이지로 이동
+   */
+  const onSubmit = async (data: SignUpFormInputs) => {
+    // 서버로 보낼 때 핸드폰 번호는 숫자만 추출
+    const phoneNumbersOnly = data.phone.replace(/-/g, "");
+
+    // API 요청 형식에 맞게 데이터 변환
+    const registerData: RegisterRequest = {
+      username: data.fullName, // fullName을 username으로 매핑
+      email: data.email,
+      password: data.password,
+      phone: phoneNumbersOnly,
+      // 주소는 필요시 추가 (API 스펙에 따라)
+    };
+
+    try {
+      await registerMutation.mutateAsync(registerData);
+      // 성공 시 메인 페이지로 이동
+      router.push("/");
+    } catch (error) {
+      // 에러는 mutation의 onError에서 처리됨
+      console.error("회원가입 실패:", error);
+    }
+  };
+
+  // 필드 값 변경 핸들러들
+  const handleDaumPostAddressChange = (daumPostAddress: string) => {
+    setValue("daumPostAddress", daumPostAddress, { shouldValidate: true });
+  };
+
+  const handleExtraAddressChange = (extraAddress: string) => {
+    setValue("extraAddress", extraAddress, { shouldValidate: true });
+  };
+
+  const handlePhoneChange = (value: string) => {
+    setValue("phone", value, { shouldValidate: true });
+  };
+
+  return {
+    // Form methods
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    errors,
+    isFormValid,
+    isLoading: registerMutation.isPending,
+
+    // Field values
+    fullName,
+    email,
+    password,
+    phone,
+    daumPostAddress,
+    extraAddress,
+
+    // Field states
+    fieldStates,
+
+    // Handlers
+    handleDaumPostAddressChange,
+    handleExtraAddressChange,
+    handlePhoneChange,
+  };
+};

--- a/apps/client/src/@service/auth/mutations.ts
+++ b/apps/client/src/@service/auth/mutations.ts
@@ -1,7 +1,21 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AUTH_QUERY_KEY } from "./queryKey";
 import { AuthService } from "./api";
 import { toast } from "react-toastify";
+
+export function useRegister() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: AuthService.register,
+    onSuccess: () => {
+      toast.success("회원가입이 완료되었습니다!");
+      qc.invalidateQueries({ queryKey: AUTH_QUERY_KEY.base });
+    },
+    onError: (error) => {
+      toast.error(error.message || "회원가입에 실패했습니다.");
+    },
+  });
+}
 
 export function useLogout() {
   const qc = useQueryClient();


### PR DESCRIPTION
# 회원가입 API 연결 및 SignUpForm 리팩토링

## 📋 개요

회원가입 기능을 실제 API와 연결하고, SignUpForm 컴포넌트를 리팩토링하여 유지보수성과 가독성을 개선했습니다.

## ✨ 주요 변경사항

### 1. 회원가입 API 연결

- `useRegister` mutation hook 추가 (`@service/auth/mutations.ts`)
- `/api/auth/register` 엔드포인트와 연동
- 성공/실패 시 toast 메시지 표시
- 회원가입 성공 시 메인 페이지로 자동 이동

### 2. SignUpForm 리팩토링

- **관심사의 분리**: UI와 로직을 분리하여 컴포넌트 가독성 향상
  - `SignUpForm.tsx`: UI 렌더링만 담당 (203줄 → 148줄)
  - `useSignUpForm.ts`: 폼 로직, 상태 관리, API 호출 담당 (신규 파일)
- **재사용성 향상**: 커스텀 훅으로 분리하여 다른 곳에서도 재사용 가능
- **유지보수성 개선**: 로직 변경 시 훅만 수정하면 되도록 구조 개선

### 3. 사용자 경험 개선

- 로딩 상태 표시 (제출 중 버튼 비활성화 및 텍스트 변경)
- 에러 처리 개선 (toast 메시지로 사용자에게 명확한 피드백)
- 폼 필드 상태 관리 최적화

## 📁 변경된 파일

### 신규 파일

- `apps/client/src/@layout/signup/hooks/useSignUpForm.ts`
  - 회원가입 폼 로직을 관리하는 커스텀 훅
  - 폼 상태, 유효성 검사, 제출 로직 포함

### 수정된 파일

- `apps/client/src/@service/auth/mutations.ts`
  - `useRegister` mutation hook 추가
  - 회원가입 성공/실패 처리 로직 구현

- `apps/client/src/@layout/signup/SignUpForm.tsx`
  - 로직을 `useSignUpForm` 훅으로 이동
  - UI 렌더링에만 집중하도록 리팩토링
  - 로딩 상태 표시 추가

## 🔄 API 스펙

### Request

```typescript
POST /api/auth/register
{
  username: string;    // fullName에서 매핑
  email: string;
  password: string;
  phone: string;      // 하이픈 제거된 숫자만
  roleId?: string;
}
```

### Response

```typescript
{
  userId: number;
  email: string;
}
```

## 🎯 리팩토링 효과

### Before

- 하나의 컴포넌트에 UI + 로직 + 상태 관리가 모두 섞여 있음
- 코드가 길고 복잡하여 읽기 어려움
- 테스트와 재사용이 어려움

### After

- UI와 로직이 명확히 분리됨
- 컴포넌트가 간결해져 가독성 향상
- 로직을 독립적으로 테스트 가능
- 다른 컴포넌트에서도 폼 로직 재사용 가능

## 🧪 테스트 체크리스트

- [ ] 회원가입 폼 유효성 검사 동작 확인
- [ ] API 호출 성공 시 메인 페이지로 이동 확인
- [ ] API 호출 실패 시 에러 메시지 표시 확인
- [ ] 로딩 상태 표시 확인
- [ ] 폼 제출 중 버튼 비활성화 확인

## 📝 참고사항

- 주소 필드는 현재 API 요청에 포함되지 않음 (필요시 추후 추가 가능)
- 환경 변수 `NEXT_PUBLIC_API_URL` 설정 필요
- 회원가입 성공 시 메인 페이지(`/`)로 이동
